### PR TITLE
update: Container() -> KeyedSubtree()

### DIFF
--- a/lib/flutter_phoenix.dart
+++ b/lib/flutter_phoenix.dart
@@ -27,7 +27,7 @@ class _PhoenixState extends State<Phoenix> {
 
   @override
   Widget build(BuildContext context) {
-    return Container(
+    return KeyedSubtree(
       key: _key,
       child: widget.child,
     );


### PR DESCRIPTION
Really thankful for the package!
This PR is to change the `Container` widget with the `KeyedSubtree` as it is mentioned by the @rrousselGit
`KeyedSubtree` is a widget that just builds its child which is useful for attaching a key to any existing widget of an app.
As this doesn't completely close the app from the OS level because it just does from the app level, I found `KeyedSubtree` to be the preferable one.

Any ideas or any thoughts on this are welcome...