### PR TITLE
Migrate from Jcenter to Maven Central

### DIFF
--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -2,7 +2,7 @@ buildscript {
     ext.kotlin_version = '1.3.50'
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
@@ -14,7 +14,7 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 


### PR DESCRIPTION
Following as Jcenter shutting down.
https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/